### PR TITLE
Add support for errors in tests

### DIFF
--- a/src/providers/sidebarProvider.ts
+++ b/src/providers/sidebarProvider.ts
@@ -142,7 +142,10 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
           this.reportData.summary.total === 0
         ) {
           this.renderState('empty');
-        } else if (this.reportData.failedTests.length === 0) {
+        } else if (
+          this.reportData.failedTests.length === 0 &&
+          this.reportData.summary.error === 0
+        ) {
           this.renderState('all-passed');
         } else {
           this.renderState('results');

--- a/src/renderers/styles.ts
+++ b/src/renderers/styles.ts
@@ -56,10 +56,41 @@ export function getStyles(): string {
       color: var(--vscode-sideBarSectionHeader-foreground);
     }
 
+    .summary-total {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: var(--spacing-sm) 0;
+      margin-bottom: var(--spacing-md);
+    }
+
+    .total-value {
+      font-size: 24px;
+      font-weight: 500;
+      line-height: 1.2;
+      color: var(--vscode-foreground);
+    }
+
+    .total-label {
+      font-size: 11px;
+      color: var(--vscode-descriptionForeground);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-top: var(--spacing-xs);
+    }
+
     .summary-stats {
       display: grid;
       grid-template-columns: repeat(4, 1fr);
       gap: var(--spacing-sm);
+    }
+
+    /* Responsive: 2 columns when sidebar is narrow */
+    @media (max-width: 300px) {
+      .summary-stats {
+        grid-template-columns: repeat(2, 1fr);
+      }
     }
 
     .stat-item {
@@ -104,6 +135,10 @@ export function getStyles(): string {
       color: var(--vscode-testing-iconSkipped, #cca700);
     }
 
+    .stat-error {
+      color: var(--vscode-testing-iconError, #f59e0b);
+    }
+
     .progress-bar {
       display: flex;
       height: 4px;
@@ -120,6 +155,16 @@ export function getStyles(): string {
 
     .progress-failed {
       background: var(--vscode-testing-iconFailed, #f14c4c);
+      transition: width 0.3s ease;
+    }
+
+    .progress-error {
+      background: var(--vscode-testing-iconError, #f59e0b);
+      transition: width 0.3s ease;
+    }
+
+    .progress-skipped {
+      background: var(--vscode-testing-iconSkipped, #cca700);
       transition: width 0.3s ease;
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,4 +37,4 @@ export type SidebarState =
   | 'error'
   | 'loading';
 
-export type TestStatus = 'failed' | 'passed' | 'skipped';
+export type TestStatus = 'failed' | 'passed' | 'skipped' | 'error';


### PR DESCRIPTION

<img width="355" height="838" alt="Screenshot 2026-01-25 at 10 29 44 PM" src="https://github.com/user-attachments/assets/4c5ad837-1f95-475a-94c8-1b71d2fcbc1e" />


closes #10 

 - Add error to TestStatus type                                                                                          
- Display errors in a separate "Errors" section in sidebar                                                                
- Update summary UI: Total Tests centered on top, 4 status items in responsive grid below                                                                           
- Update progress bar to show all 4 statuses (passed, failed, skipped, error)                                             
- Make summary grid responsive (4 cols → 2 cols on narrow widths)  